### PR TITLE
feat(detector & SLO checks): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a "Fail early" option to the detector and SLO checks. When enabled (the default, matching the previous behavior), the check fails as soon as a deviating state is observed. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step (with a past-tense message, since the state may have recovered by then).
 - fix: guard the detector and SLO checks against targets missing the name attribute instead of panicking
 
 ## v1.0.12

--- a/extdetectors/check.go
+++ b/extdetectors/check.go
@@ -47,6 +47,11 @@ type DetectorCheckState struct {
 	ExpectedState         string
 	StateCheckMode        string
 	StateCheckSuccess     bool
+	FailEarly             bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating state was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewDetectorStateCheckAction() action_kit_sdk.Action[DetectorCheckState] {
@@ -145,6 +150,16 @@ func (m *DetectorStateCheckAction) Describe() action_kit_api.ActionDescription {
 				Required: new(true),
 				Order:    new(3),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating state is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(4),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -205,6 +220,12 @@ func (m *DetectorStateCheckAction) Prepare(_ context.Context, state *DetectorChe
 		return nil, new(extension_kit.ToError("Target is missing the '"+attributeName+"' attribute.", nil))
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	state.DetectorId = detectorId[0]
 	state.DetectorName = detectorName[0]
 	state.Start = start
@@ -254,29 +275,47 @@ func DetectorCheckStatus(ctx context.Context, state *DetectorCheckState, client 
 	completed := now.After(state.End)
 	var checkError *action_kit_api.ActionKitError
 
+	// recordDeviation either fails immediately (fail early) or remembers the deviation so it can be
+	// reported once the step ends (fail at end, using the past-tense message since the state may have
+	// recovered by then).
+	recordDeviation := func(present, past string) {
+		if state.FailEarly {
+			checkError = new(action_kit_api.ActionKitError{
+				Title:  present,
+				Status: extutil.Ptr(action_kit_api.Failed),
+			})
+		} else {
+			state.DeviationSeen = true
+			state.DeviationTitle = past
+		}
+	}
+
 	if len(state.ExpectedState) > 0 {
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			for _, incident := range incidents {
 				if state.ExpectedState != incident.AnomalyState {
-					checkError = new(action_kit_api.ActionKitError{
-						Title: fmt.Sprintf("One of the incidents of the detector '%s' has state '%s' whereas '%s' is expected.",
-							state.DetectorName,
-							incident.AnomalyState,
-							state.ExpectedState),
-						Status: extutil.Ptr(action_kit_api.Failed),
-					})
+					recordDeviation(
+						fmt.Sprintf("One of the incidents of the detector '%s' has state '%s' whereas '%s' is expected.",
+							state.DetectorName, incident.AnomalyState, state.ExpectedState),
+						fmt.Sprintf("One of the incidents of the detector '%s' had state '%s' whereas '%s' is expected.",
+							state.DetectorName, incident.AnomalyState, state.ExpectedState))
 					break
 				}
 			}
 			if state.ExpectedState != NoIncident {
 				if len(incidents) == 0 {
-					checkError = new(action_kit_api.ActionKitError{
-						Title: fmt.Sprintf("No incidents found for detector '%s' whereas incident(s) with '%s' state is expected.",
-							state.DetectorName,
-							state.ExpectedState),
-						Status: extutil.Ptr(action_kit_api.Failed),
-					})
+					recordDeviation(
+						fmt.Sprintf("No incidents found for detector '%s' whereas incident(s) with '%s' state is expected.",
+							state.DetectorName, state.ExpectedState),
+						fmt.Sprintf("No incidents were found for detector '%s' whereas incident(s) with '%s' state is expected.",
+							state.DetectorName, state.ExpectedState))
 				}
+			}
+			if !state.FailEarly && completed && state.DeviationSeen {
+				checkError = new(action_kit_api.ActionKitError{
+					Title:  state.DeviationTitle,
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
 			}
 		} else if state.StateCheckMode == stateCheckModeAtLeastOnce {
 			for _, incident := range incidents {

--- a/extdetectors/check_test.go
+++ b/extdetectors/check_test.go
@@ -185,6 +185,7 @@ func TestStatus_AllTheTime_Failure(t *testing.T) {
 		End:                   time.Now().Add(2 * time.Minute),
 		ExpectedState:         Anomalous,
 		StateCheckMode:        stateCheckModeAllTheTime,
+		FailEarly:             true,
 	}
 
 	statusResult, err := DetectorCheckStatus(context.Background(), &state, RestyClient)
@@ -195,6 +196,55 @@ func TestStatus_AllTheTime_Failure(t *testing.T) {
 		t.Errorf("Expected error due to mismatching incident state, but got nil")
 	} else if !strings.Contains(statusResult.Error.Title, "has state") {
 		t.Errorf("Unexpected error message: %s", statusResult.Error.Title)
+	}
+}
+
+func TestStatus_AllTheTime_FailAtEnd(t *testing.T) {
+	// Simulate an incident that does not match the expected state.
+	now := time.Now()
+	incident := Incident{
+		AnomalyState:                Ok, // not matching expected Anomalous
+		AnomalyStateUpdateTimestamp: now.Add(-time.Minute).UnixMilli(),
+	}
+	ts := newTestServer([]Incident{incident}, http.StatusOK)
+	defer ts.Close()
+
+	client := resty.New().SetBaseURL(ts.URL)
+	RestyClient = client
+
+	state := DetectorCheckState{
+		DetectorId:     "detector1",
+		DetectorName:   "Detector One",
+		Start:          now.Add(-2 * time.Minute),
+		End:            now.Add(2 * time.Minute), // not yet completed
+		ExpectedState:  Anomalous,
+		StateCheckMode: stateCheckModeAllTheTime,
+		FailEarly:      false,
+	}
+
+	// Not completed: a deviation is observed but must not fail early.
+	statusResult, err := DetectorCheckStatus(context.Background(), &state, RestyClient)
+	if err != nil {
+		t.Fatalf("DetectorCheckStatus returned error: %v", err)
+	}
+	if statusResult.Error != nil {
+		t.Errorf("Expected no error before the step ends (fail early disabled), got %s", statusResult.Error.Title)
+	}
+	if !state.DeviationSeen {
+		t.Error("Expected the deviation to be remembered")
+	}
+
+	// Completed: the remembered deviation is reported with the past-tense message.
+	state.End = now.Add(-time.Second)
+	statusResult, err = DetectorCheckStatus(context.Background(), &state, RestyClient)
+	if err != nil {
+		t.Fatalf("DetectorCheckStatus returned error: %v", err)
+	}
+	if statusResult.Error == nil {
+		t.Fatal("Expected an error at the end of the step")
+	}
+	if !strings.Contains(statusResult.Error.Title, "had state") {
+		t.Errorf("Expected past-tense message, got: %s", statusResult.Error.Title)
 	}
 }
 

--- a/extslos/check.go
+++ b/extslos/check.go
@@ -47,6 +47,11 @@ type SloCheckState struct {
 	ExpectedState      string
 	StateCheckMode     string
 	StateCheckSuccess  bool
+	FailEarly          bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating state was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewSloStateCheckAction() action_kit_sdk.Action[SloCheckState] {
@@ -141,6 +146,16 @@ func (m *SloStateCheckAction) Describe() action_kit_api.ActionDescription {
 				Required: new(true),
 				Order:    new(3),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating state is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(4),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -199,6 +214,12 @@ func (m *SloStateCheckAction) Prepare(_ context.Context, state *SloCheckState, r
 	sloName := request.Target.Attributes[attributeName]
 	if len(sloName) == 0 {
 		return nil, new(extension_kit.ToError("Target is missing the '"+attributeName+"' attribute.", nil))
+	}
+
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
 	}
 
 	state.SloID = sloId[0]
@@ -276,10 +297,24 @@ func SLOCheckStatus(ctx context.Context, state *SloCheckState, client *resty.Cli
 
 	if state.StateCheckMode == stateCheckModeAllTheTime {
 		if slosFound.Count == 0 {
+			// The message is already phrased in the past tense, so it reads correctly whether reported
+			// immediately (fail early) or at the end of the step (fail at end).
+			title := fmt.Sprintf("The SLO '%s' was not found with the expected state '%s'.",
+				state.SloName,
+				state.ExpectedState)
+			if state.FailEarly {
+				checkError = new(action_kit_api.ActionKitError{
+					Title:  title,
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
+			} else {
+				state.DeviationSeen = true
+				state.DeviationTitle = title
+			}
+		}
+		if !state.FailEarly && completed && state.DeviationSeen {
 			checkError = new(action_kit_api.ActionKitError{
-				Title: fmt.Sprintf("The SLO '%s' was not found with the expected state '%s'.",
-					state.SloName,
-					state.ExpectedState),
+				Title:  state.DeviationTitle,
 				Status: extutil.Ptr(action_kit_api.Failed),
 			})
 		}

--- a/extslos/check_test.go
+++ b/extslos/check_test.go
@@ -105,6 +105,7 @@ func TestStatus_AllTheTime_NoResult(t *testing.T) {
 		End:                now.Add(time.Minute),
 		ExpectedState:      breachAlertsTriggered,
 		StateCheckMode:     stateCheckModeAllTheTime,
+		FailEarly:          true,
 	}
 	// Simulate an empty response.
 	respStruct := Response{
@@ -125,6 +126,50 @@ func TestStatus_AllTheTime_NoResult(t *testing.T) {
 	if statusResult.Error == nil {
 		t.Errorf("Expected error due to no SLO found, got nil")
 	} else if !strings.Contains(statusResult.Error.Title, "was not found") {
+		t.Errorf("Unexpected error message: %s", statusResult.Error.Title)
+	}
+}
+
+func TestStatus_AllTheTime_FailAtEnd(t *testing.T) {
+	now := time.Now()
+	state := SloCheckState{
+		SloID:          "slo1",
+		SloName:        "SLO One",
+		Start:          now.Add(-time.Minute),
+		End:            now.Add(time.Minute), // not yet completed
+		ExpectedState:  breachAlertsTriggered,
+		StateCheckMode: stateCheckModeAllTheTime,
+		FailEarly:      false,
+	}
+	respBytes, _ := json.Marshal(Response{Count: 0, Results: []Slo{}})
+	ts := newTestServer(respBytes, http.StatusOK)
+	defer ts.Close()
+
+	client := resty.New().SetBaseURL(ts.URL)
+	RestyClient = client
+
+	// Not completed: the deviation must not fail early.
+	statusResult, err := SLOCheckStatus(context.Background(), &state, RestyClient)
+	if err != nil {
+		t.Fatalf("SLOCheckStatus returned error: %v", err)
+	}
+	if statusResult.Error != nil {
+		t.Errorf("Expected no error before the step ends (fail early disabled), got %s", statusResult.Error.Title)
+	}
+	if !state.DeviationSeen {
+		t.Error("Expected the deviation to be remembered")
+	}
+
+	// Completed: the remembered deviation is reported.
+	state.End = now.Add(-time.Second)
+	statusResult, err = SLOCheckStatus(context.Background(), &state, RestyClient)
+	if err != nil {
+		t.Fatalf("SLOCheckStatus returned error: %v", err)
+	}
+	if statusResult.Error == nil {
+		t.Fatal("Expected an error at the end of the step")
+	}
+	if !strings.Contains(statusResult.Error.Title, "was not found") {
 		t.Errorf("Unexpected error message: %s", statusResult.Error.Title)
 	}
 }


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. A check can fail early (on the first deviating event) or only at the end of the step, with no way to choose. This adds a per-check option, following the reference implementation in `extension-datadog` (and matching dynatrace/grafana/kafka/appdynamics/cloudfoundry).

## Change

Adds a **`failEarly` boolean** to both Splunk checks (detector state, SLO state):

- **Enabled (default)** — the check fails as soon as a deviating state is observed (today's `All the time` behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare` (when the key is absent), so **existing experiments are non-breaking**.
- Fail-at-end is implemented by remembering the deviation in state (`DeviationSeen`/`DeviationTitle`). The detector check has two deviation points, routed through a small `recordDeviation` closure.
- For the detector messages that were present tense ("has state"), the fail-at-end variant uses **past tense** ("had state"); the "No incidents found" / SLO "was not found" messages were already historical and are reused as-is.
- Only affects `All the time` mode; `At least once` can only be evaluated at the end of the step.

## Note

Both checks evaluate determinate states (incident states / SLO count), so the "unknown/no-data silently passes" bug fixed in datadog#216 does **not** apply here.

## Tests

- Set `FailEarly: true` on the existing `All the time` failure tests (they assert immediate failure with time not yet up).
- Added `AllTheTime_FailAtEnd` tests for both checks (deferred failure, past-tense message for the detector).
- All `extdetectors` and `extslos` tests pass, `go vet` clean.