### PR TITLE
fix: emit detector/SLO check metrics immediately on Start

### DIFF
--- a/extdetectors/check.go
+++ b/extdetectors/check.go
@@ -236,8 +236,17 @@ func (m *DetectorStateCheckAction) Prepare(_ context.Context, state *DetectorChe
 	return nil, nil
 }
 
-func (m *DetectorStateCheckAction) Start(_ context.Context, _ *DetectorCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *DetectorStateCheckAction) Start(ctx context.Context, state *DetectorCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := DetectorCheckStatus(ctx, state, RestyClient)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *DetectorStateCheckAction) Status(ctx context.Context, state *DetectorCheckState) (*action_kit_api.StatusResult, error) {

--- a/extslos/check.go
+++ b/extslos/check.go
@@ -232,8 +232,17 @@ func (m *SloStateCheckAction) Prepare(_ context.Context, state *SloCheckState, r
 	return nil, nil
 }
 
-func (m *SloStateCheckAction) Start(_ context.Context, _ *SloCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *SloStateCheckAction) Start(ctx context.Context, state *SloCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := SLOCheckStatus(ctx, state, RestyClient)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *SloStateCheckAction) Status(ctx context.Context, state *SloCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `Start()` was a no-op for both `Check Detector Incidents` and `Check SLO Alerts`, so the first metric only appeared after the first `Status()` poll (one `CallInterval` — 1s and 2s respectively — after the check started).
- `Start()` now reuses the same status-check logic as `Status()` for both actions, so the first metric is emitted immediately when the check starts.

## Test plan
- [x] `go build ./...`
- [x] `go test ./extdetectors/... ./extslos/...`